### PR TITLE
Footer event links styling modified to avoid overflowing. 

### DIFF
--- a/kodkollektivet/templates/base.html
+++ b/kodkollektivet/templates/base.html
@@ -126,7 +126,6 @@
       </div>
 
       <div class="goto">
-        <h3>Go to</h3>
         <div>
           <div class="links">
             <ul class="pages">
@@ -148,12 +147,12 @@
             <ul class="event-links">
 	      {% if upcomming_events %}
               <h4>Events</h4>
-	      {% for event in upcomming_events %}
+	      {% for event in upcomming_events|slice:":10" %}
               <li><a href="{% url "kodkollektivet:eventdetailview" event.slug %}">{{event}}</a></li>
 	      {% endfor %}
 	      {% else %}
 	      <h4>Events</h4>
-	      {% for event in old_events %}
+	      {% for event in old_events|slice:":10" %}
               <li><a href="{% url "kodkollektivet:eventdetailview" event.slug %}">{{event}}</a></li>
 	      {% endfor %}
 	      {% endif %}

--- a/static/css/compass/sass/_base.sass
+++ b/static/css/compass/sass/_base.sass
@@ -126,10 +126,10 @@ a
   color: $main-color-light
   text-decoration: none
   letter-spacing: 1px
-  &:hover
-    color: white
   &:visited
     color: $main-color-light
+  &:hover
+    color: white
 
 ul
   list-style-type: none

--- a/static/css/compass/sass/_footer.sass
+++ b/static/css/compass/sass/_footer.sass
@@ -7,7 +7,7 @@ footer
   .contact,.goto
     @include span-columns(4)
     h3
-      margin: 100px 0 20px 0
+      margin: 60px 0 20px 0
       letter-spacing: 2px
       color: white
   .contact
@@ -20,6 +20,7 @@ footer
     @include span-columns(4)
  
   .goto
+    margin-top: 60px
     h3
       margin-left: 30px
     div
@@ -39,8 +40,17 @@ footer
           h4
             margin: 0 0 5px -5px
             color: white
-            font-size: 12px
+            font-size: 18px
           text-align: left
+          &.event-links
+            width: 100%
+            max-width: 300px
+            li
+              white-space: nowrap
+              text-overflow: ellipsis
+              overflow: hidden
+              margin-bottom: 5px
+
   @media screen and (max-width: 1135px)
     padding: 0 50px 50px 50px
     .logo-footer
@@ -48,7 +58,7 @@ footer
     .contact,.goto
       @include span-columns(6)
       &:not(:first-child)
-        margin-top: 30px
+        margin-top: 40px
       h3 
-        margin: 50px
+        margin: 0 0 50px 0
         text-align: center


### PR DESCRIPTION
- Now displaying maximum of 10 events.
- "Go to" text removed for space.
- Added a bit of space between the links
- Link text no longer linebreaks. Overflow will cause ellipsis.
- Links :hover-styling (white) how has priority over the :visited styling.

Related Issue: #35 - Event links in footer are too long