### PR TITLE
Preventing crawlers from reading board members' email

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.6
 MAINTAINER jherrlin@gmail.com
 
 ENV PYTHONUNBUFFERED 1

--- a/kodkollektivet/models.py
+++ b/kodkollektivet/models.py
@@ -1,13 +1,21 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime, timedelta
+import os
 
 from django.db import models
 from django.utils.text import slugify
 from django.utils import timezone
+from django.conf import settings
 
 from wand.image import Image
+from wand.drawing import Drawing
+from wand.color import Color
 
+def handle_uploaded_file(fname, f):
+    with open(fname, 'wb+') as destination:
+        for chunk in f.chunks():
+            destination.write(chunk)
 
 class PostQuerySet(models.QuerySet):
     def published(self):
@@ -30,6 +38,19 @@ class BoardMember(models.Model):
                 img.transform(resize='x250')
                 img.compression_quality = 90
                 img.save(filename=self.photo.path)
+        if self.email:
+            with Drawing() as draw:
+                with Image(width=300,
+                           height=30,
+                           background=Color('white')) as emailimg:
+
+                    draw.font = '/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf'
+                    draw.font_color = 'black'
+                    draw.font_size = 16
+                    draw.text(5, int(emailimg.height * 12 / 13), self.email)
+
+                    draw.draw(emailimg)
+                    emailimg.save(filename=os.path.dirname(self.photo.path) +'/' + self.last_name + '.email.png')
 
     def __str__(self):
         return '{} {}'.format(self.first_name, self.last_name)

--- a/kodkollektivet/templates/board.html
+++ b/kodkollektivet/templates/board.html
@@ -12,13 +12,11 @@
       <h2>{{ member.position|title }}</h2>
       <img src={{ member.photo.url }} />
       <p>{{ member.first_name }} {{ member.last_name }}</p>
-      {% if member.email %}<p>Email:{{ member.email }}</p>{% endif %}
+      {% if member.email %}<p>Email: <img src="/media/board-images/{{ member.last_name}}.email.png"/></p>{% endif %}
       {% if member.telephone %}<p>Tel:{{ member.telephone }}</p>{% endif %}
     </div>
   </section>
   {% endfor %}
 </div>
-
-<p class="center">Bilderna är tagna av Petter Hammarbäck, IEC</p>
 
 {% endblock content %}


### PR DESCRIPTION
Credits to John for the first working prototype

The feature is implemented by generating an image of the email text and serving it to the clients